### PR TITLE
Update transformer and tokenizer in setup.py to new versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ extras["dev"] = extras["testing"] + extras["quality"] + ["mecab-python3", "sciki
 
 setup(
     name="transformers",
-    version="2.11.0",
+    version="4.35.0",
     author="Thomas Wolf, Lysandre Debut, Victor Sanh, Julien Chaumond, Sam Shleifer, Patrick von Platen, Google AI Language Team Authors, Open AI team Authors, Facebook AI Authors, Carnegie Mellon University Authors",
     author_email="thomas@huggingface.co",
     description="State-of-the-art Natural Language Processing for TensorFlow 2.0 and PyTorch",
@@ -109,7 +109,7 @@ setup(
     packages=find_packages("src"),
     install_requires=[
         "numpy",
-        "tokenizers == 0.8.0-rc1",
+        "tokenizers == 0.15.0",
         # dataclasses for Python versions that don't have it
         "dataclasses;python_version<'3.7'",
         # utilities from PyPA to e.g. compare versions
@@ -127,7 +127,7 @@ setup(
         # for XLM
         "sacremoses",
         # for superglue
-        "sklearn",
+        "scikit-learn",
         "experiment_impact_tracker",
         "torch",
         # for superglue - impact tracker

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ extras["dev"] = extras["testing"] + extras["quality"] + ["mecab-python3", "sciki
 
 setup(
     name="transformers",
-    version="4.35.0",
+    version="4.36.2",
     author="Thomas Wolf, Lysandre Debut, Victor Sanh, Julien Chaumond, Sam Shleifer, Patrick von Platen, Google AI Language Team Authors, Open AI team Authors, Facebook AI Authors, Carnegie Mellon University Authors",
     author_email="thomas@huggingface.co",
     description="State-of-the-art Natural Language Processing for TensorFlow 2.0 and PyTorch",


### PR DESCRIPTION
Due to older version of transformer it was facing issues and was asking to install rust in the docker image. When I installed rust still it was giving issues for pyo3 due to network calls.
The newer versions are building the docker image correctly!

Error traceback:
```
Building wheel for tokenizers (pyproject.toml): started
#12 55.96 Building wheel for tokenizers (pyproject.toml): finished with status 'error'
#12 55.97 error: subprocess-exited-with-error
#12 55.97
#12 55.97 × Building wheel for tokenizers (pyproject.toml) did not run successfully.
#12 55.97 │ exit code: 1
#12 55.97 ╰─> [48 lines of output]
#12 55.97 /tmp/pip-build-env-1s4lt8xo/overlay/lib/python3.9/site-packages/setuptools/dist.py:314: InformationOnly: Normalizing '0.8.0.rc1' to '0.8.0rc1'
#12 55.97 self.metadata.version = self._normalize_version(self.metadata.version)
#12 55.97 running bdist_wheel
#12 55.97 running build
#12 55.97 running build_py
#12 55.97 creating build
#12 55.97 creating build/lib.linux-x86_64-cpython-39
#12 55.97 creating build/lib.linux-x86_64-cpython-39/tokenizers
#12 55.97 copying tokenizers/init.py -> build/lib.linux-x86_64-cpython-39/tokenizers
#12 55.97 creating build/lib.linux-x86_64-cpython-39/tokenizers/models
#12 55.97 copying tokenizers/models/init.py -> build/lib.linux-x86_64-cpython-39/tokenizers/models
#12 55.97 creating build/lib.linux-x86_64-cpython-39/tokenizers/decoders
#12 55.97 copying tokenizers/decoders/init.py -> build/lib.linux-x86_64-cpython-39/tokenizers/decoders
#12 55.97 creating build/lib.linux-x86_64-cpython-39/tokenizers/normalizers
#12 55.97 copying tokenizers/normalizers/init.py -> build/lib.linux-x86_64-cpython-39/tokenizers/normalizers
#12 55.97 creating build/lib.linux-x86_64-cpython-39/tokenizers/pre_tokenizers
#12 55.97 copying tokenizers/pre_tokenizers/init.py -> build/lib.linux-x86_64-cpython-39/tokenizers/pre_tokenizers
#12 55.97 creating build/lib.linux-x86_64-cpython-39/tokenizers/processors
#12 55.97 copying tokenizers/processors/init.py -> build/lib.linux-x86_64-cpython-39/tokenizers/processors
#12 55.97 creating build/lib.linux-x86_64-cpython-39/tokenizers/trainers
#12 55.97 copying tokenizers/trainers/init.py -> build/lib.linux-x86_64-cpython-39/tokenizers/trainers
#12 55.97 creating build/lib.linux-x86_64-cpython-39/tokenizers/implementations
#12 55.97 copying tokenizers/implementations/init.py -> build/lib.linux-x86_64-cpython-39/tokenizers/implementations
#12 55.97 copying tokenizers/implementations/base_tokenizer.py -> build/lib.linux-x86_64-cpython-39/tokenizers/implementations
#12 55.97 copying tokenizers/implementations/bert_wordpiece.py -> build/lib.linux-x86_64-cpython-39/tokenizers/implementations
#12 55.97 copying tokenizers/implementations/byte_level_bpe.py -> build/lib.linux-x86_64-cpython-39/tokenizers/implementations
#12 55.97 copying tokenizers/implementations/char_level_bpe.py -> build/lib.linux-x86_64-cpython-39/tokenizers/implementations
#12 55.97 copying tokenizers/implementations/sentencepiece_bpe.py -> build/lib.linux-x86_64-cpython-39/tokenizers/implementations
#12 55.97 copying tokenizers/init.pyi -> build/lib.linux-x86_64-cpython-39/tokenizers
#12 55.97 copying tokenizers/models/init.pyi -> build/lib.linux-x86_64-cpython-39/tokenizers/models
#12 55.97 copying tokenizers/decoders/init.pyi -> build/lib.linux-x86_64-cpython-39/tokenizers/decoders
#12 55.97 copying tokenizers/normalizers/init.pyi -> build/lib.linux-x86_64-cpython-39/tokenizers/normalizers
#12 55.97 copying tokenizers/pre_tokenizers/init.pyi -> build/lib.linux-x86_64-cpython-39/tokenizers/pre_tokenizers
#12 55.97 copying tokenizers/processors/init.pyi -> build/lib.linux-x86_64-cpython-39/tokenizers/processors
#12 55.97 copying tokenizers/trainers/init.pyi -> build/lib.linux-x86_64-cpython-39/tokenizers/trainers
#12 55.97 running build_ext
#12 55.97 running build_rust
#12 55.97 error: can't find Rust compiler
#12 55.97
#12 55.97 If you are using an outdated pip version, it is possible a prebuilt wheel is available for this package but pip is not able to install from it. Installing from the wheel would avoid the need for a Rust compiler.
```